### PR TITLE
Add throttling rule to request event

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -66,6 +66,7 @@ type RequestEntry struct {
 	RespBytes            string `json:"resp_bytes"`
 	RespHeaderBytes      string `json:"resp_header_bytes"`
 	RespBodyBytes        string `json:"resp_body_bytes"`
+	ThrottlingRule       string `json:"throttling_rule"`
 }
 
 // OutputEvent is simply the marshal format for the outputted merged event
@@ -102,6 +103,7 @@ type OutputEvent struct {
 	RespHeaderBytes      string      `json:"resp_header_bytes"`
 	RespBodyBytes        string      `json:"resp_body_bytes"`
 	WafEvents            []OutputWaf `json:"waf_events"`
+	ThrottlingRule       string      `json:"throttling_rule"`
 }
 
 // OutputWaf is the output format for the waf event
@@ -215,6 +217,7 @@ func (engine *ECE) WriteEvent(reqId string) (err error) {
 			RespBytes:            event.RequestEntries[0].RespBytes,
 			RespHeaderBytes:      event.RequestEntries[0].RespHeaderBytes,
 			RespBodyBytes:        event.RequestEntries[0].RespBodyBytes,
+			ThrottlingRule:       event.RequestEntries[0].ThrottlingRule,
 		}
 	} else {
 		outputEvent = OutputEvent{

--- a/pkg/service/service_fixtures.go
+++ b/pkg/service/service_fixtures.go
@@ -8,7 +8,7 @@ func TestWafEntryMessage() string {
 
 // TestWebEntryMessage a canned example of a request log entry
 func TestWebEntryMessage() string {
-	return `{"event_type":"req","service_id":"AAABBBB","request_id":"65df6a015f5a85fdf3559acad090ce1c567cbceacefea4baa476406b1d876392","start_time":"1521150005","fastly_info":"PASS","datacenter":"SFO","client_ip":"8.8.8.8","req_method":"POST","req_uri":"L2luZGV4Lmh0bWwK","req_h_host":"api.scribd.com","req_h_user_agent":"Zm9vLzEuMQo=","req_h_accept_encoding":"gzip","req_header_bytes":"338","req_body_bytes":"852","waf_logged":"0","waf_blocked":"0","waf_failures":"0","waf_executed":"1","anomaly_score":"0","sql_injection_score":"0","rfi_score":"0","lfi_score":"0","rce_score":"0","php_injection_score":"0","session_fixation_score":"0","http_violation_score":"0","xss_score":"0","resp_status":"200","resp_bytes":"697","resp_header_bytes":"620","resp_body_bytes":"77"}`
+	return `{"event_type":"req","service_id":"AAABBBB","request_id":"65df6a015f5a85fdf3559acad090ce1c567cbceacefea4baa476406b1d876392","start_time":"1521150005","fastly_info":"PASS","datacenter":"SFO","client_ip":"8.8.8.8","req_method":"POST","req_uri":"L2luZGV4Lmh0bWwK","req_h_host":"api.scribd.com","req_h_user_agent":"Zm9vLzEuMQo=","req_h_accept_encoding":"gzip","req_header_bytes":"338","req_body_bytes":"852","waf_logged":"0","waf_blocked":"0","waf_failures":"0","waf_executed":"1","anomaly_score":"0","sql_injection_score":"0","rfi_score":"0","lfi_score":"0","rce_score":"0","php_injection_score":"0","session_fixation_score":"0","http_violation_score":"0","xss_score":"0","resp_status":"200","resp_bytes":"697","resp_header_bytes":"620","resp_body_bytes":"77","throttling_rule":"password_reset"}`
 }
 
 // TestWafEntry an example of a WafEntry Object
@@ -58,6 +58,7 @@ func TestWebEntry() RequestEntry {
 		RespBytes:            "697",
 		RespHeaderBytes:      "620",
 		RespBodyBytes:        "77",
+		ThrottlingRule:       "password_reset",
 	}
 }
 
@@ -93,6 +94,7 @@ func TestOutputEvent() OutputEvent {
 		RespBytes:            "697",
 		RespHeaderBytes:      "620",
 		RespBodyBytes:        "77",
+		ThrottlingRule:       "password_reset",
 
 		RuleIds: []int{0},
 		WafEvents: []OutputWaf{


### PR DESCRIPTION
If request is throttled, output rule that got triggered throttling. That way we can see it in the WAF logs, even though it's not part of WAF