### PR TITLE
Add a flag to mark event as throttled

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -104,6 +104,7 @@ type OutputEvent struct {
 	RespBodyBytes        string      `json:"resp_body_bytes"`
 	WafEvents            []OutputWaf `json:"waf_events"`
 	ThrottlingRule       string      `json:"throttling_rule"`
+	Throttled            int         `json:"throttled"`
 }
 
 // OutputWaf is the output format for the waf event
@@ -264,6 +265,10 @@ func (engine *ECE) WriteEvent(reqId string) (err error) {
 	}
 
 	outputEvent.RuleIds = ids
+
+	if outputEvent.ThrottlingRule != "" {
+		outputEvent.Throttled = 1
+	}
 
 	outputBytes, err := json.Marshal(outputEvent)
 

--- a/pkg/service/service_fixtures.go
+++ b/pkg/service/service_fixtures.go
@@ -95,6 +95,7 @@ func TestOutputEvent() OutputEvent {
 		RespHeaderBytes:      "620",
 		RespBodyBytes:        "77",
 		ThrottlingRule:       "password_reset",
+		Throttled:            1,
 
 		RuleIds: []int{0},
 		WafEvents: []OutputWaf{


### PR DESCRIPTION
This is to make search in kibana easier. Whenever throttling rule is not
empty, add a `throttled:1`. Kibana doesn't seem to be happy if searching
by an empty string